### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,50 @@
+
+
+# Descripción del proyecto
+
+Algunos demos de Java para práctica diaria o pruebas.
+
+Incluye Java y frameworks relacionados; los usuarios pueden explorar por su cuenta. Si encuentras algún problema, por favor abre un issue.
+
+Alguno del código podría haberse completado hace tiempo. Mi nivel es limitado, por lo que el contenido es solo para referencia.
+
+# Clasificación del código
+## Middleware de contenedores
+- [x] activemq
+- [x] kafka
+- [x] docker
+- [x] zookeeper
+# Operaciones con bases de datos
+- [x] druid-demo
+- [x] mongodb
+- [x] orm
+- [x] testgsdb
+## Pruebas
+- [x] jmeter
+- [x] junit
+## Núcleo de Java
+- [x] java-core
+- [x] spi
+## Ecosistema Spring
+- [x] springboot
+- [x] spring-cloud
+- [x] spring-in-action
+## Contenedores Web
+- [x] howtomcatwork
+- [x] servlet
+## Uso de Maven
+- [x] maven-in-action
+## Microservicios RPC
+- [x] dubbo
+- [x] microservice
+- [x] rest-on-jaxws
+- [x] webservice
+
+# Requisitos del entorno
+1. Java 1.8+
+2. Spring Boot 2.x+
+3. MySQL 5.7.5+
+4. Redis 5.0.7+
+
+# Referencias
+https://github.com/alibaba/spring-cloud-alibaba/tree/2023.x/spring-cloud-alibaba-examples


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

Generated by `qwen3.6-35b-a3b via local API`.